### PR TITLE
Fix windows path issue in file collector

### DIFF
--- a/packages/plugin-collector-files/src/index.js
+++ b/packages/plugin-collector-files/src/index.js
@@ -2,12 +2,16 @@ import path from "path";
 
 const debug = require("debug")("phenomic:plugin:collector-files");
 
+function normalizeWindowsPath(value: string) {
+  return value.replace(/(\/|\\)+/g, path.sep);
+}
+
 export function getKey(name: string, json: PhenomicTransformResult): string {
   if (json.data.path) {
     return json.data.path;
   }
   // normalize windows path
-  name = name.replace(/(\/|\\)+/g, path.sep);
+  name = normalizeWindowsPath(name);
   return path.join(
     path
       .dirname(name)
@@ -91,6 +95,7 @@ export default function() {
   return {
     name: "@phenomic/plugin-collector-files",
     collect(db: PhenomicDB, name: string, json: PhenomicTransformResult) {
+      name = normalizeWindowsPath(name);
       const pathSegments = name.split(path.sep);
       const collectionName = pathSegments[0];
       const key = getKey(name, json);


### PR DESCRIPTION
Not sure if this is related to issue #1032 but no pages were returned as part of a collection for me while taking the alpha for a spin on my windows machine. This change fixes it.