### PR TITLE
Use `posts.node.list` instead of `posts.list`

### DIFF
--- a/packages/preset-react-app/docs/getting-started/4.md
+++ b/packages/preset-react-app/docs/getting-started/4.md
@@ -36,7 +36,7 @@ const Home =  ({ posts }) => (
   <div>
     <h1>Home</h1>
     <ul>
-      { posts && posts.node && posts.list &&
+      { posts && posts.node && posts.node.list &&
         posts.node.list.map((post) => (
           <li key={post.id}>
             <Link to={ `/blog/${ post.id }`}>{ post.title || post.id }</Link>


### PR DESCRIPTION
I was stepping through the getting started docs and noticed the conditional to display the list of posts has a bug.

`posts && posts.node && posts.list` should be `posts && posts.node && posts.node.list` as `list` is nested under `node`.


![phenomic-getting-started-4-debugging](https://cloud.githubusercontent.com/assets/2133004/26763396/ecebf60a-4917-11e7-996c-e2365d61b872.png)

