### PR TITLE
Return a valid React element in the Layout definition

### DIFF
--- a/packages/preset-react-app/docs/getting-started/7.md
+++ b/packages/preset-react-app/docs/getting-started/7.md
@@ -5,7 +5,7 @@ Simple problem means simple solution: you need to use a common wrapper component
 ```js
 import Head from "react-helmet"
 
-const Layout = (props) => {
+const Layout = (props) => (
   <div>
     <Head>
       <html lang="en" /> { /* this is valid react-helmet usage! */ }
@@ -20,7 +20,7 @@ const Layout = (props) => {
       { /* ... */ }
     </footer>
   </div>
-}
+)
 ```
 
 Now you can replace previous `<div>` used in previous example:


### PR DESCRIPTION
When running through the docs example I was getting the error

> A valid React element (or null) must be returned. You may have returned undefined, an array or some other invalid object.

This was pretty easy to fix. I opted to sway the curly braces for parenthesis but you could also add a `return`.