### PR TITLE
fixed package.json examples in docs

### DIFF
--- a/packages/preset-react-app/docs/getting-started/2.md
+++ b/packages/preset-react-app/docs/getting-started/2.md
@@ -35,7 +35,7 @@ Let's add this commands into some scripts of the ``package.json``
   ...
   "scripts": {
     "start": "phenomic start",
-    "build": "phenomic build",
+    "build": "phenomic build"
   }
 }
 ```
@@ -61,7 +61,7 @@ Let's add this commands into some scripts of the ``package.json``
   },
   "scripts": {
     "start": "phenomic start",
-    "build": "phenomic build",
+    "build": "phenomic build"
   }
 }
 ```


### PR DESCRIPTION
Fixing `package.json` examples