### PR TITLE
Docs: create a content/ path

### DIFF
--- a/packages/preset-react-app/docs/getting-started/2.md
+++ b/packages/preset-react-app/docs/getting-started/2.md
@@ -68,6 +68,13 @@ Let's add this commands into some scripts of the ``package.json``
 
 </details>
 
+Before you start the server, you need a ``content/`` path. An empty one would do to start with.
+
+```sh
+mkdir content
+touch content/.gitignore
+```
+
 Now we can use ``npm start`` to start the website/app.
 Website/app should be accessible via [http://localhost:3333](http://localhost:3333).
 


### PR DESCRIPTION
Prevents this error:

```
> phenomic start

⚡️ Hey! Let's get on with it
✨ Open http://localhost:3333
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: resolve_projpath: path `/Users/rsc/Projects/phenomic/content` does not exist
    at BunserBuf.<anonymous> (/Users/rsc/Projects/phenomic/node_modules/fb-watchman/index.js:95:23)
    at emitOne (events.js:96:13)
    at BunserBuf.emit (events.js:188:7)
    at BunserBuf.process (/Users/rsc/Projects/phenomic/node_modules/bser/index.js:292:10)
    at /Users/rsc/Projects/phenomic/node_modules/bser/index.js:247:12
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```