### PR TITLE
replace `Layouts` with `PostLayouts`

### DIFF
--- a/packages/preset-react-app/docs/getting-started/7.md
+++ b/packages/preset-react-app/docs/getting-started/7.md
@@ -57,9 +57,9 @@ const PostLayouts = {
 }
 
 const BlogPost = ({ page }) => ({
-  const PostLayout = Layouts[page.node.type] || "article"
+  const PostLayout = PostLayouts[page.node.type] || "article"
   // alternatively you can use a default layout, not just a tag
-  // const PostLayout = Layouts[page.node.type] || PostLayouts.default
+  // const PostLayout = PostLayouts[page.node.type] || PostLayouts.default
   return (
     <div>
       {page.node && (


### PR DESCRIPTION
`Layouts` is not defined among the context, but `PostLayouts` is. I guess it might be easier to understand while the layouts array has the same variable name, no matter `Layouts` or `PostLayouts`.