### PR TITLE
Unicode spechars fix

### DIFF
--- a/src/_utils/serialize/index.js
+++ b/src/_utils/serialize/index.js
@@ -1,5 +1,5 @@
 // @flow
 
 export default (value: any): string => {
-  return JSON.stringify(value).replace(/\<\/script>/g, "<\\/script>")
+  return JSON.stringify(value).replace(/\<\/script>/g, "<\\/script>").replace(/\u2028/g,"\\u2028").replace(/\u2029/g,"\\u2029")
 }

--- a/src/_utils/serialize/index.js
+++ b/src/_utils/serialize/index.js
@@ -1,5 +1,6 @@
 // @flow
 
 export default (value: any): string => {
-  return JSON.stringify(value).replace(/\<\/script>/g, "<\\/script>").replace(/\u2028/g,"\\u2028").replace(/\u2029/g,"\\u2029")
+  return JSON.stringify(value).replace(/\<\/script>/g, "<\\/script>")
+    .replace(/\u2028/g,"\\u2028").replace(/\u2029/g,"\\u2029")
 }


### PR DESCRIPTION
fix for bad unicode characters in the markdown and `JSON.stringify`

i guess a similar fix should be applied in @1.0

see also : 

http://www.thespanner.co.uk/2011/07/25/the-json-specification-is-now-wrong/

https://bugs.chromium.org/p/v8/issues/detail?can=2&start=0&num=100&q=&colspec=ID%20Type%20Status%20Priority%20Owner%20Summary%20HW%20OS%20Area%20Stars&groupby=&sort=&id=1939

https://github.com/expressjs/express/issues/1132#issuecomment-10100419





