### PR TITLE
``@phenomic/core`` + ``@phenomic/api-client``: Make `path` parameter for query optional

### DIFF
--- a/flow/interfaces/phenomic.js
+++ b/flow/interfaces/phenomic.js
@@ -1,11 +1,11 @@
 export type PhenomicDB = {
   destroy: () => Promise<void>,
   put: (
-    sub: string | Array<string>,
+    sub?: string | Array<string>,
     key: string,
     value: any
   ) => Promise<Object>,
-  get: (sub: string | Array<string>, key: string) => Promise<Object>,
+  get: (sub?: string | Array<string>, key: string) => Promise<Object>,
   getPartial: (sub: string | Array<string>, key: string) => Promise<void>,
   getList: (
     sub: string | Array<string>,

--- a/flow/interfaces/phenomic.js
+++ b/flow/interfaces/phenomic.js
@@ -1,11 +1,11 @@
 export type PhenomicDB = {
   destroy: () => Promise<void>,
   put: (
-    sub?: string | Array<string>,
+    sub: null | string | Array<string>,
     key: string,
     value: any
   ) => Promise<Object>,
-  get: (sub?: string | Array<string>, key: string) => Promise<Object>,
+  get: (sub: null | string | Array<string>, key: string) => Promise<Object>,
   getPartial: (sub: string | Array<string>, key: string) => Promise<void>,
   getList: (
     sub: string | Array<string>,

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -24,7 +24,6 @@
   "main": "lib/index.js",
   "files": ["lib"],
   "dependencies": {
-    "debug": "^2.6.0",
-    "invariant": "^2.2.2"
+    "debug": "^2.6.0"
   }
 }

--- a/packages/api-client/src/query.js
+++ b/packages/api-client/src/query.js
@@ -1,12 +1,6 @@
-import invariant from "invariant";
-
 const debug = require("debug")("phenomic:api-client");
 
 function query(config: PhenomicQueryConfig): PhenomicQueryConfig {
-  invariant(
-    typeof config.path === "string",
-    "A query must at least contain a path"
-  );
   debug("query", config);
 
   // note that during static build, we initiate the query with no id

--- a/packages/core/src/api/index.js
+++ b/packages/core/src/api/index.js
@@ -148,7 +148,7 @@ function createServer(db: PhenomicDB, plugins: PhenomicPlugins) {
   ) {
     debug(req.url, JSON.stringify(req.params));
     try {
-      const resource = await db.get(undefined, req.params["0"]);
+      const resource = await db.get(null, req.params["0"]);
       res.json(resource.value);
     } catch (error) {
       console.error(error);

--- a/packages/core/src/api/index.js
+++ b/packages/core/src/api/index.js
@@ -142,6 +142,20 @@ function createServer(db: PhenomicDB, plugins: PhenomicPlugins) {
     }
   });
 
+  server.get("/item/*.json", async function(
+    req: express$Request,
+    res: express$Response
+  ) {
+    debug(req.url, JSON.stringify(req.params));
+    try {
+      const resource = await db.get(undefined, req.params["0"]);
+      res.json(resource.value);
+    } catch (error) {
+      console.error(error);
+      res.status(404).end();
+    }
+  });
+
   // Install the plugins
   plugins.forEach(plugin => {
     if (typeof plugin.define === "function") {

--- a/packages/core/src/db/index.js
+++ b/packages/core/src/db/index.js
@@ -84,39 +84,45 @@ const db = {
       });
     });
   },
-  put(sub: string | Array<string>, key: string, value: any): Promise<Object> {
+  put(sub?: string | Array<string>, key: string, value: any): Promise<Object> {
     return new Promise((resolve, reject) => {
       const data = { ...value, key };
-      return getSublevel(level, sub).put(key, data, options, error => {
-        if (error) {
-          reject(error);
-          return;
-        } else {
-          resolve(data);
+      return (sub ? getSublevel(level, sub) : level).put(
+        key,
+        data,
+        options,
+        error => {
+          if (error) {
+            reject(error);
+            return;
+          } else {
+            resolve(data);
+          }
         }
-      });
+      );
     });
   },
-  get(sub: string | Array<string>, key: string): Promise<Object> {
+  get(sub?: string | Array<string>, key: string): Promise<Object> {
     return new Promise((resolve, reject) => {
-      return getSublevel(level, sub).get(key, options, async function(
-        error,
-        data
-      ) {
-        if (error) {
-          reject(error);
-        } else {
-          const { body, ...metadata } = data.data;
-          const relatedData = await getDataRelations(metadata);
-          resolve({
-            key: key,
-            value: {
-              ...relatedData,
-              body
-            }
-          });
+      return (sub ? getSublevel(level, sub) : level).get(
+        key,
+        options,
+        async function(error, data) {
+          if (error) {
+            reject(error);
+          } else {
+            const { body, ...metadata } = data.data;
+            const relatedData = await getDataRelations(metadata);
+            resolve({
+              key: key,
+              value: {
+                ...relatedData,
+                body
+              }
+            });
+          }
         }
-      });
+      );
     });
   },
   getPartial(sub: string | Array<string>, key: string): Promise<Object> {

--- a/packages/core/src/db/index.js
+++ b/packages/core/src/db/index.js
@@ -84,7 +84,11 @@ const db = {
       });
     });
   },
-  put(sub?: string | Array<string>, key: string, value: any): Promise<Object> {
+  put(
+    sub: null | string | Array<string>,
+    key: string,
+    value: any
+  ): Promise<Object> {
     return new Promise((resolve, reject) => {
       const data = { ...value, key };
       return (sub ? getSublevel(level, sub) : level).put(
@@ -102,7 +106,7 @@ const db = {
       );
     });
   },
-  get(sub?: string | Array<string>, key: string): Promise<Object> {
+  get(sub: null | string | Array<string>, key: string): Promise<Object> {
     return new Promise((resolve, reject) => {
       return (sub ? getSublevel(level, sub) : level).get(
         key,

--- a/packages/plugin-collector-files/src/index.js
+++ b/packages/plugin-collector-files/src/index.js
@@ -118,6 +118,10 @@ export default function() {
           debug(`collecting ${relativeKey} for path '${pathName}'`);
           return Promise.all([
             // full resource, not sorted
+            db.put(undefined, key, {
+              ...adjustedJSON,
+              id: key
+            }),
             db.put([pathName], relativeKey, {
               ...adjustedJSON,
               id: relativeKey

--- a/packages/plugin-collector-files/src/index.js
+++ b/packages/plugin-collector-files/src/index.js
@@ -118,7 +118,7 @@ export default function() {
           debug(`collecting ${relativeKey} for path '${pathName}'`);
           return Promise.all([
             // full resource, not sorted
-            db.put(undefined, key, {
+            db.put(null, key, {
               ...adjustedJSON,
               id: key
             }),


### PR DESCRIPTION
Because we can.