### PR TITLE
Add Link component to react-router so first post doesn't blow error

### DIFF
--- a/packages/preset-react-app/docs/getting-started/3.md
+++ b/packages/preset-react-app/docs/getting-started/3.md
@@ -30,6 +30,7 @@ export default createApp(() => (
 We also need to create a ``BlogPostContainer`` component to render the posts.
 
 ```js
+import { Router, Route, browserHistory, Link } from "react-router";
 import {
   createApp,
   createContainer,


### PR DESCRIPTION
CURRENTLY: The tutorial has `BlogPost` component referring to a `Link` component. The tutorial has not instructed to add to the top import to `react-router`, so when the user runs the tutorial exactly as it says, it blows an error and doesn't load the first post as expected.

EXPECTED: The user can follow the tutorial exactly and get the result promised.

TO BE DONE: Add an extra line explaining that they need to update the react-router import to include link