### PR TITLE
Plugin-collector-files: Fix date parse from filename when using sub folders

### DIFF
--- a/packages/plugin-collector-files/src/__tests__/index.js
+++ b/packages/plugin-collector-files/src/__tests__/index.js
@@ -4,7 +4,8 @@ import {
   getAuthors,
   getFields,
   getFieldValue,
-  injectData
+  injectData,
+  parsePath
 } from "..";
 
 it("should be able to generate keys", () => {
@@ -92,5 +93,12 @@ it("should be able to inject date from filename in data", () => {
     data: {
       filename: "test.md"
     }
+  });
+});
+
+it("should be able to parse filepath", () => {
+  expect(parsePath("posts/november/2017-11-11-test.md")).toEqual({
+    filename: "2017-11-11-test.md",
+    allPaths: ["posts", "posts/november", "posts/november/2017-11-11-test.md"]
   });
 });

--- a/packages/plugin-collector-files/src/index.js
+++ b/packages/plugin-collector-files/src/index.js
@@ -98,18 +98,24 @@ export function injectData(
   };
 }
 
+export function parsePath(name: string) {
+  const pathSegments = name.split(sep);
+  const allPaths = pathSegments.reduce((acc, v) => {
+    acc.push(acc.length > 0 ? acc[acc.length - 1] + sep + v : v);
+    return acc;
+  }, []);
+  const filename = pathSegments[pathSegments.length - 1];
+  return { filename, allPaths };
+}
+
 export default function() {
   return {
     name: "@phenomic/plugin-collector-files",
     collect(db: PhenomicDB, name: string, json: PhenomicTransformResult) {
       name = normalizeWindowsPath(name);
       const key = getKey(name, json);
-      const adjustedJSON = injectData(name, json);
-      const pathSegments = name.split(sep);
-      const allPaths = pathSegments.reduce((acc, v) => {
-        acc.push(acc.length > 0 ? acc[acc.length - 1] + sep + v : v);
-        return acc;
-      }, []);
+      const { filename, allPaths } = parsePath(name);
+      const adjustedJSON = injectData(filename, json);
       return Promise.all(
         allPaths.map(pathName => {
           const relativeKey = key.replace(pathName + sep, "");


### PR DESCRIPTION
injectData expects filename only (not full path). Includes test. Closes #1096.