### PR TITLE
Plugin-bundler-webpack: Make webpack follow configured outdir

### DIFF
--- a/packages/plugin-bundler-webpack/src/webpack.config.js
+++ b/packages/plugin-bundler-webpack/src/webpack.config.js
@@ -15,7 +15,9 @@ module.exports = (config: PhenomicConfig) => ({
   },
   output: {
     publicPath: "/", // @todo make this dynamic
-    path: path.join(process.cwd(), "dist"),
+    path: path.isAbsolute(config.outdir)
+      ? config.outdir
+      : path.join(process.cwd(), config.outdir),
     ...(process.env.PHENOMIC_ENV !== "static"
       ? {
           filename: "phenomic/[name].js",


### PR DESCRIPTION
Webpack config had a hard coded "dist" public path, resulting in two output directories if outdir was specified in package.json:phenomic.