### PR TITLE
Fix typo in preset-react-app doc

### DIFF
--- a/packages/preset-react-app/docs/getting-started/9.md
+++ b/packages/preset-react-app/docs/getting-started/9.md
@@ -9,7 +9,7 @@ Everytime we use a star (`*`) and (sometimes) a parameter (`:name`) in a
 exist. With our previous example, we will need to add some case in multiple
 places.
 
-Let's create an component to render the error
+Let's create a component to render the error
 
 ```js
 const PageError = ({ error }) => {


### PR DESCRIPTION
Hello,

I just updated "**an** component" to "**a** component".