### PR TITLE
Add undefined check to file delete watcher

### DIFF
--- a/packages/core/src/watch/index.js
+++ b/packages/core/src/watch/index.js
@@ -100,7 +100,7 @@ function createWatcher(config: { path: string, plugins: PhenomicPlugins }) {
   watcher.on("delete", (filepath, root) => {
     debug("watcher: file deleted", filepath, root);
     const index = files.find(
-      (file: PhenomicContentFile) => file.name === filepath
+      (file: PhenomicContentFile) => file && file.name === filepath
     );
     if (index) {
       delete files[files.indexOf(index)];


### PR DESCRIPTION
Fixes #1208
Fixes #1157 

The watcher close function gets called with an `undefined` file sometimes when you rename/delete a file. The default Node.js fs.watch function is known for having some bugs, but adding an undefined check before deleting the file fixes the problem until the webpack team fixes it.