### PR TITLE
Remove unneeded Js.Object.assign

### DIFF
--- a/packages/api-client/src/phenomicApiClient.re
+++ b/packages/api-client/src/phenomicApiClient.re
@@ -1,5 +1,5 @@
-[@bs.module "@phenomic/api-client/lib/query"] external internalQuery : Js.t({..}) => Js.t({..}) =
-  "query";
+[@bs.module "@phenomic/api-client/lib/query"]
+external internalQuery : Js.t({..}) => Js.t({..}) = "query";
 
 type queryConfigItem = {
   path: string,
@@ -28,10 +28,15 @@ type queryConfig =
   | List(listConfig)
   | PaginatedList(paginatedListConfig);
 
-let query = (queryConfig) =>
+/* We need Js.Obj.assign here because OCaml can't handle returning multiple return types
+   from the same function. This makes it so it thinks it's just a Js.Obj.t */
+let query = queryConfig =>
   switch queryConfig {
   | Item(queryConfigItem) =>
-    Js.Obj.assign(Js.Obj.empty(), {"path": queryConfigItem.path, "id": queryConfigItem.id})
+    Js.Obj.assign(
+      Js.Obj.empty(),
+      {"path": queryConfigItem.path, "id": queryConfigItem.id}
+    )
   | List(queryConfigList) =>
     Js.Obj.assign(
       Js.Obj.empty(),


### PR DESCRIPTION
The Object.assign here seems to be unnecessary as we don't mutate or add more fields to it. We also doesn't save it for later use so we don't really care if it's mutated in JS-land either.