### PR TITLE
Feature/configurable root

### DIFF
--- a/packages/plugin-bundler-webpack/src/webpack.config.js
+++ b/packages/plugin-bundler-webpack/src/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = (config: PhenomicConfig) => ({
         require.resolve("webpack-hot-middleware/client"),
       process.env.PHENOMIC_ENV !== "static" &&
         require.resolve("react-hot-loader/patch"),
-      path.join(config.root, "App.js")
+      path.join(config.path, "App.js")
     ].filter(item => item)
   },
   output: {

--- a/packages/plugin-bundler-webpack/src/webpack.config.js
+++ b/packages/plugin-bundler-webpack/src/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = (config: PhenomicConfig) => ({
         require.resolve("webpack-hot-middleware/client"),
       process.env.PHENOMIC_ENV !== "static" &&
         require.resolve("react-hot-loader/patch"),
-      "./App.js"
+      `${config.root}/App.js`
     ].filter(item => item)
   },
   output: {

--- a/packages/plugin-bundler-webpack/src/webpack.config.js
+++ b/packages/plugin-bundler-webpack/src/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = (config: PhenomicConfig) => ({
         require.resolve("webpack-hot-middleware/client"),
       process.env.PHENOMIC_ENV !== "static" &&
         require.resolve("react-hot-loader/patch"),
-      `${config.root}/App.js`
+      path.join(config.root, "App.js")
     ].filter(item => item)
   },
   output: {


### PR DESCRIPTION
Just uses the `config.path` variable to configure where `App.js` is.

Not everyone wants to have `App.js` in the root of their repo. 


I personally want it in
```
public/
  CNAME.txt
src/
  App.js
  content/
    something.md
```
The other reason for this is way docker volume mounts work. Files can be mounted, but when they change the file inside the container isn't a correct reflection of that change, causes errors.

I get around this by ensuring I mount as much of my src code as folders rather than files.

