### PR TITLE
Initial draft for fs-as-database solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.0.0",
+    "@glennsl/bs-jest": "^0.4.4",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.0",
     "babel-jest": "^23.6.0",

--- a/packages/fs-as-database/README.md
+++ b/packages/fs-as-database/README.md
@@ -1,0 +1,5 @@
+# @phenomic/fs-as-database
+
+> Access files content via queries on a database (SQL/GraphQL)
+
+➡ More details at [phenomic.io](https://phenomic.io/)

--- a/packages/fs-as-database/__tests__/Db_test.re
+++ b/packages/fs-as-database/__tests__/Db_test.re
@@ -1,0 +1,34 @@
+open Jest;
+open Expect;
+
+let sample = {
+  "date": "2017-06-02T00:00:00.000Z",
+  "title": "Introducing Phenomic 1.0.0 first alpha",
+  "authors": ["bloodyowl"],
+  "body": {
+    "t": "div",
+    "c": ["Hi there. Alpha blah blah."]
+  }
+}
+
+let schema = Db.schemaFromJson(sample)
+let tables = schema |> Db.tablesFromSchema("test")
+let sqlStatements = tables |> Db.sqlStatementsFromTables
+
+test("should generate schema from json", () => {
+  expect(
+    schema
+  ) |> toMatchSnapshot
+});
+
+test("should generate tables structure from schema", () => {
+  expect(
+    tables
+  ) |> toMatchSnapshot
+});
+
+test("should generate sql from tables structures", () => {
+  expect(
+    sqlStatements
+  ) |> toMatchSnapshot
+});

--- a/packages/fs-as-database/bsconfig.json
+++ b/packages/fs-as-database/bsconfig.json
@@ -1,0 +1,18 @@
+{
+  "name": "@phenomic/fs-as-database",
+  "refmt": 3,
+  "reason": {
+    "react-jsx": 2
+  },
+  "sources": [
+    {
+      "dir": "src",
+      "subdirs": true
+    },
+    {
+      "dir": "__tests__",
+      "type": "dev"
+    }
+  ],
+  "bs-dev-dependencies": ["@glennsl/bs-jest"]
+}

--- a/packages/fs-as-database/package.json
+++ b/packages/fs-as-database/package.json
@@ -1,0 +1,40 @@
+{
+  "private": true,
+  "name": "@phenomic/fs-as-database",
+  "version": "1.0.0-beta.4",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "https://github.com/phenomic/phenomic.git",
+  "homepage": "https://phenomic.io",
+  "license": "MIT",
+  "authors": [
+    "Maxime Thirouin (MoOx)"
+  ],
+  "keywords": [
+    "static",
+    "website",
+    "generator",
+    "compiler",
+    "fs",
+    "files",
+    "database",
+    "sql",
+    "graphql"
+  ],
+  "description": "Access files content via queries on a database (SQL/GraphQL)",
+  "main": "lib/index.js",
+  "files": [
+    "lib",
+    "src",
+    "!**/__tests__"
+  ],
+  "dependencies": {
+    "better-sqlite3": "^5.0.1"
+  },
+  "engines": {
+    "node": ">=4.2.0",
+    "npm": ">=3.0.0",
+    "yarn": ">=1.0.0"
+  }
+}

--- a/packages/fs-as-database/src/BsBetterSqlite3.re
+++ b/packages/fs-as-database/src/BsBetterSqlite3.re
@@ -1,0 +1,24 @@
+type database = {
+  .
+  "inTransaction": bool,
+  "open": bool,
+  "memory": bool,
+  "readonly": bool,
+  "name": string,
+};
+type statement;
+type statementInfo = {
+  .
+  "changes": int,
+  "lastInsertRowid": int,
+};
+type options = {. "memory": bool};
+
+[@bs.new] [@bs.module]
+external make : (string, options) => database = "better-sqlite3";
+
+[@bs.send] external close : database => unit = "";
+
+[@bs.send] external prepare : (database, string) => statement = "";
+
+[@bs.send] external run : statement => statementInfo = "";

--- a/packages/fs-as-database/src/Db.re
+++ b/packages/fs-as-database/src/Db.re
@@ -1,0 +1,72 @@
+let joinListOfString = (~glue=",", listOfString) =>
+  String.concat(glue, listOfString);
+
+type table = {
+  name: string,
+  fields: list((string, string)),
+};
+
+type database = list(table);
+
+type schemaItem =
+  | String(string)
+  | Number(float)
+  | List(list(schemaItem))
+  | Complex(string);
+
+type schema = list(schemaItem);
+
+let rec schemaItemFromJs = value =>
+  switch (Js.typeof(value)) {
+  | "string" => String(value->Obj.magic)
+  | "number" => Number(value->Obj.magic)
+  | _ when Js.Array.isArray(value) =>
+    List(value->Obj.magic->Belt.Array.map(schemaItemFromJs)->Array.to_list)
+  | _ => Complex(value->Obj.magic)
+  };
+
+let schemaFromJson = json =>
+  json
+  ->Obj.magic
+  ->Js.Dict.entries
+  ->Array.to_list
+  ->Belt.List.map(((key, value)) => (key, schemaItemFromJs(value)));
+
+let rec tablesFromSchema = (name, schema) => {
+  let (fields, tablesFromDeepStructures) =
+    Belt.List.reduce(schema, ([], []), ((fields, tables), (key, value)) =>
+      switch (value) {
+      | String(_string) => (List.append(fields, [(key, "TEXT")]), tables)
+      | Number(_number) => (List.append(fields, [(key, "REAL")]), tables)
+      | List(list) => (
+          fields,
+          List.append(
+            tables,
+            tablesFromSchema(key, [("__id__", List.hd(list))]),
+          ),
+        )
+      | Complex(_data) => (List.append(fields, [(key, "BLOB")]), tables)
+      }
+    );
+  [{name, fields}, ...tablesFromDeepStructures];
+};
+
+let sqlStatementsFromTables = (tables) => {
+  Belt.List.reduce(tables, [], (statements, table) => {
+    let sqlForFields = Belt.List.reduce(table.fields, [], (columns, (key, datatype)) => List.append(columns, [key ++ " " ++ datatype]));
+    List.append(statements, ["CREATE TABLE " ++ table.name ++ "(" ++ joinListOfString(sqlForFields) ++ ");"])
+  });
+}
+
+let makeDb = (~name="phenomic.db", ~inMemory, _) =>
+  BsBetterSqlite3.make(name, {"memory": inMemory});
+/*
+ export default {
+   addResource(type, id, data) {
+     let currentModel = schemaFromJson(type, data);
+
+     // db.prepare("")
+   }
+   // addRelation(id)
+ };
+ */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,6 +1168,13 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@glennsl/bs-jest@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@glennsl/bs-jest/-/bs-jest-0.4.4.tgz#71cd14217023efd14e09f0030c08f2103e90d734"
+  integrity sha512-jO//I5OO2YQO8mbjMTD8oI2aXfLvsz3tzAWF/k/VTUDsrvDglgtj5APE8Qz1yNzJIQIo8u55UQOH/ojtCGryEA==
+  dependencies:
+    jest "^23.5.0"
+
 "@lerna/add@^3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.4.1.tgz#d41068317e30f530df48220d256b5e79690b1877"
@@ -2556,7 +2563,7 @@ babel-plugin-emotion@^8.0.12:
 
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
-  resolved "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
   integrity sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.13.0"
@@ -2726,6 +2733,14 @@ better-assert@~1.0.0:
   integrity sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=
   dependencies:
     callsite "1.0.0"
+
+better-sqlite3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-5.0.1.tgz#5addb5dcf18c9374c570a1eab7694e67fc9437a3"
+  integrity sha512-dyZk+gDYNPw14maYX5LG/2SCUTiB7jCvETd+bBYqhFyji3oG+UQFN452sUWSjCHCmfg1JtMbLT7WmqB8GLq8Gw==
+  dependencies:
+    integer "^2.1.0"
+    tar "^4.4.6"
 
 big.js@^3.1.3:
   version "3.2.0"
@@ -6773,6 +6788,11 @@ inquirer@^6.1.0, inquirer@^6.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+integer@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/integer/-/integer-2.1.0.tgz#29134ea2f7ba3362ed4dbe6bcca992b1f18ff276"
+  integrity sha512-vBtiSgrEiNocWvvZX1RVfeOKa2mCHLZQ2p9nkQkQZ/BvEiY+6CcUz0eyjvIiewjJoeNidzg2I+tpPJvpyspL1w==
+
 interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
@@ -7591,7 +7611,7 @@ jest-worker@^23.2.0:
   dependencies:
     merge-stream "^1.0.1"
 
-jest@^23.0.0:
+jest@^23.0.0, jest@^23.5.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-23.6.0.tgz#ad5835e923ebf6e19e7a1d7529a432edfee7813d"
   integrity sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==
@@ -12052,7 +12072,7 @@ tar@^2.0.0:
     fstream "^1.0.2"
     inherits "2"
 
-tar@^4, tar@^4.4.3:
+tar@^4, tar@^4.4.3, tar@^4.4.6:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
   integrity sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==


### PR DESCRIPTION
# `fliptable.gif`

Will closes #1265 

The idea here is:

- take some content on the fs (we do this already)
- apply transformation to feed database with json (so: markdown to json, etc like it's currently - no change here)
- instead of doing a weird database that we cannot alter easily (especially removing things previously injected) we build a sql schema from data received (and alter tables if needed, from previous schema diff)
- then we actually create/alter the sql db, if needed
- and inject actual data (or remove/alter)
- on top of that we add
  - a simple api to retrieve things (like current Phenomic content api)
  - graphql access