### PR TITLE
[Feature] Update ReasonReact JSX to version 3

### DIFF
--- a/examples/reason-react-app/App.js
+++ b/examples/reason-react-app/App.js
@@ -11,18 +11,12 @@ import { make as ErrorPage } from "./lib/es6/src/components/ErrorPage.bs.js";
 
 const routes = () => (
   <Router history={browserHistory}>
-    <Route
-      path="/"
-      component={withPhenomicApi(Home.jsComponent, Home.queries)}
-    />
+    <Route path="/" component={withPhenomicApi(Home.make, Home.queries)} />
     <Route
       path="/after/:after"
-      component={withPhenomicApi(Home.jsComponent, Home.queries)}
+      component={withPhenomicApi(Home.make, Home.queries)}
     />
-    <Route
-      path="blog/*"
-      component={withPhenomicApi(Post.jsComponent, Post.queries)}
-    />
+    <Route path="blog/*" component={withPhenomicApi(Post.make, Post.queries)} />
     <Route path="*" component={ErrorPage} />
     <Route path="404.html" component={ErrorPage} />
   </Router>

--- a/examples/reason-react-app/App.js
+++ b/examples/reason-react-app/App.js
@@ -7,7 +7,7 @@ import { withPhenomicApi } from "@phenomic/preset-react-app/lib/es6/src/phenomic
 
 import * as Home from "./lib/es6/src/components/Home.bs.js";
 import * as Post from "./lib/es6/src/components/Post.bs.js";
-import ErrorPage from "./lib/es6/src/components/ErrorPage.bs.js";
+import { make as ErrorPage } from "./lib/es6/src/components/ErrorPage.bs.js";
 
 const routes = () => (
   <Router history={browserHistory}>

--- a/examples/reason-react-app/App.js
+++ b/examples/reason-react-app/App.js
@@ -7,7 +7,7 @@ import { withPhenomicApi } from "@phenomic/preset-react-app/lib/es6/src/phenomic
 
 import * as Home from "./lib/es6/src/components/Home.bs.js";
 import * as Post from "./lib/es6/src/components/Post.bs.js";
-import { make as ErrorPage } from "./lib/es6/src/components/ErrorPage.bs.js";
+import ErrorPage from "./lib/es6/src/components/ErrorPage.bs.js";
 
 const routes = () => (
   <Router history={browserHistory}>

--- a/examples/reason-react-app/bsconfig.json
+++ b/examples/reason-react-app/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/example-reason-react-app",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "suffix": ".bs.js",
   "package-specs": {

--- a/examples/reason-react-app/package.json
+++ b/examples/reason-react-app/package.json
@@ -6,13 +6,13 @@
     "@phenomic/cli": "^1.0.0-beta.11",
     "@phenomic/core": "^1.0.0-beta.11",
     "@phenomic/preset-react-app": "^1.0.0-beta.11",
-    "bs-platform": "^5.0.0",
+    "bs-platform": "^5.0.4",
     "npm-run-all": "^4.0.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-helmet": "^5.2.0",
     "react-router": "^3.2.0",
-    "reason-react": "^0.6.0"
+    "reason-react": "^0.7.0"
   },
   "scripts": {
     "reason:cleanup": "bsb -clean-world",
@@ -28,5 +28,6 @@
       "@phenomic/preset-react-app"
     ]
   },
-  "version": "1.0.0-beta.11"
+  "version": "1.0.0-beta.11",
+  "dependencies": {}
 }

--- a/examples/reason-react-app/package.json
+++ b/examples/reason-react-app/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@phenomic/example-reason-react-app",
   "devDependencies": {
-    "@moox/bs-react-helmet": "^1.0.0",
+    "@moox/bs-react-helmet": "^2.0.0",
     "@phenomic/cli": "^1.0.0-beta.11",
     "@phenomic/core": "^1.0.0-beta.11",
     "@phenomic/preset-react-app": "^1.0.0-beta.11",

--- a/examples/reason-react-app/package.json
+++ b/examples/reason-react-app/package.json
@@ -28,6 +28,5 @@
       "@phenomic/preset-react-app"
     ]
   },
-  "version": "1.0.0-beta.11",
-  "dependencies": {}
+  "version": "1.0.0-beta.11"
 }

--- a/examples/reason-react-app/src/Helpers.re
+++ b/examples/reason-react-app/src/Helpers.re
@@ -1,7 +1,7 @@
-let nothing = ReasonReact.null;
+let nothing = React.null;
 
-let text = ReasonReact.string;
+let text = React.string;
 
-let list = list => list |> Array.of_list |> ReasonReact.array;
+let list = list => list |> Array.of_list |> React.array;
 
 let nodeList = node => node##list |> Array.to_list;

--- a/examples/reason-react-app/src/components/ErrorPage.re
+++ b/examples/reason-react-app/src/components/ErrorPage.re
@@ -1,19 +1,11 @@
 open Helpers;
 
-let component = ReasonReact.statelessComponent("Post");
-
+[@react.component]
 let make = (~message: option(string)=?, _) => {
-  ...component,
-  render: _self =>
-    <div style={ReactDOMRe.Style.make(~fontSize="80px", ())}>
-      {switch (message) {
-       | None => "An error occured" |> text
-       | Some(msg) => msg |> text
-       }}
-    </div>,
+  <div style={ReactDOMRe.Style.make(~fontSize="80px", ())}>
+    {switch (message) {
+     | None => "An error occured" |> text
+     | Some(msg) => msg |> text
+     }}
+  </div>;
 };
-
-let default =
-  ReasonReact.wrapReasonForJs(~component, jsProps =>
-    make(~message=?Js.Nullable.toOption(jsProps##message), [||])
-  );

--- a/examples/reason-react-app/src/components/ErrorPage.re
+++ b/examples/reason-react-app/src/components/ErrorPage.re
@@ -9,3 +9,5 @@ let make = (~message: option(string)=?, _) => {
      }}
   </div>;
 };
+
+let default = make;

--- a/examples/reason-react-app/src/components/Home.re
+++ b/examples/reason-react-app/src/components/Home.re
@@ -2,13 +2,14 @@ open Helpers;
 
 [@react.component]
 let make = (~posts) => {
+  let posts' = PhenomicPresetReactApp.jsEdge(posts);
   <div>
     <BsReactHelmet>
       <title> {"Hello world" |> text} </title>
       <meta name="description" content="Everything is awesome!" />
     </BsReactHelmet>
     <h1> {"Home" |> text} </h1>
-    {switch ((posts: Types.posts)) {
+    {switch ((posts': Types.posts)) {
      | Inactive
      | Loading => "Loading ..." |> text
      | Errored => "An error occured" |> text

--- a/examples/reason-react-app/src/components/Home.re
+++ b/examples/reason-react-app/src/components/Home.re
@@ -1,65 +1,57 @@
 open Helpers;
 
-let component = ReasonReact.statelessComponent("Home");
-
+[@react.component]
 let make = (~posts) => {
-  ...component,
-  render: _self =>
-    <div>
-      <BsReactHelmet>
-        <title> {"Hello world" |> text} </title>
-        <meta name="description" content="Everything is awesome!" />
-      </BsReactHelmet>
-      <h1> {"Home" |> text} </h1>
-      {switch ((posts: Types.posts)) {
-       | Inactive
-       | Loading => "Loading ..." |> text
-       | Errored => "An error occured" |> text
-       | Idle(posts) =>
-         let postsList = posts##list |> Array.to_list;
+  <div>
+    <BsReactHelmet>
+      <title> {"Hello world" |> text} </title>
+      <meta name="description" content="Everything is awesome!" />
+    </BsReactHelmet>
+    <h1> {"Home" |> text} </h1>
+    {switch ((posts: Types.posts)) {
+     | Inactive
+     | Loading => "Loading ..." |> text
+     | Errored => "An error occured" |> text
+     | Idle(posts) =>
+       let postsList = posts##list |> Array.to_list;
+       <div>
+         <ul>
+           {postsList
+            |> List.map(item =>
+                 <li key=item##id>
+                   <PhenomicPresetReactApp.Link
+                     href={"/blog/" ++ item##id ++ "/"}>
+                     {item##title |> text}
+                   </PhenomicPresetReactApp.Link>
+                 </li>
+               )
+            |> list}
+         </ul>
          <div>
-           <ul>
-             {postsList
-              |> List.map(item =>
-                   <li key=item##id>
-                     <PhenomicPresetReactApp.Link
-                       href={"/blog/" ++ item##id ++ "/"}>
-                       {item##title |> text}
-                     </PhenomicPresetReactApp.Link>
-                   </li>
-                 )
-              |> list}
-           </ul>
-           <div>
-             {switch (posts##previous |> Js.toOption) {
-              | Some(previous) =>
-                <PhenomicPresetReactApp.Link
-                  href={
-                    posts##previousPageIsFirst
-                      ? "/" : "/after/" ++ previous ++ "/"
-                  }>
-                  {"Newer posts" |> text}
-                </PhenomicPresetReactApp.Link>
-              | None => nothing
-              }}
-             {" " |> text}
-             {switch (posts##next |> Js.toOption) {
-              | Some(next) =>
-                <PhenomicPresetReactApp.Link href={"/after/" ++ next ++ "/"}>
-                  {"Older posts" |> text}
-                </PhenomicPresetReactApp.Link>
-              | None => nothing
-              }}
-           </div>
-         </div>;
-       }}
-    </div>,
+           {switch (posts##previous |> Js.toOption) {
+            | Some(previous) =>
+              <PhenomicPresetReactApp.Link
+                href={
+                  posts##previousPageIsFirst
+                    ? "/" : "/after/" ++ previous ++ "/"
+                }>
+                {"Newer posts" |> text}
+              </PhenomicPresetReactApp.Link>
+            | None => nothing
+            }}
+           {" " |> text}
+           {switch (posts##next |> Js.toOption) {
+            | Some(next) =>
+              <PhenomicPresetReactApp.Link href={"/after/" ++ next ++ "/"}>
+                {"Older posts" |> text}
+              </PhenomicPresetReactApp.Link>
+            | None => nothing
+            }}
+         </div>
+       </div>;
+     }}
+  </div>;
 };
-
-let jsComponent =
-  ReasonReact.wrapReasonForJs(~component, jsProps =>
-    make(~posts=PhenomicPresetReactApp.jsEdge(jsProps##posts))
-  );
 
 let queries = props => {
   let posts =

--- a/examples/reason-react-app/src/components/Post.re
+++ b/examples/reason-react-app/src/components/Post.re
@@ -1,31 +1,23 @@
 open Helpers;
 
-let component = ReasonReact.statelessComponent("Post");
-
+[@react.component]
 let make = (~post) => {
-  ...component,
-  render: _self =>
-    <div>
-      {switch ((post: Types.postNode)) {
-       | Inactive
-       | Loading => "Loading ..." |> text
-       | Errored => <ErrorPage />
-       | Idle(post) =>
-         <div>
-           <BsReactHelmet>
-             <title> {post##title |> text} </title>
-           </BsReactHelmet>
-           <h1> {post##title |> text} </h1>
-           <PhenomicPresetReactApp.BodyRenderer body=post##body />
-         </div>
-       }}
-    </div>,
+  <div>
+    {switch ((post: Types.postNode)) {
+     | Inactive
+     | Loading => "Loading ..." |> text
+     | Errored => <ErrorPage />
+     | Idle(post) =>
+       <div>
+         <BsReactHelmet>
+           <title> {post##title |> text} </title>
+         </BsReactHelmet>
+         <h1> {post##title |> text} </h1>
+         <PhenomicPresetReactApp.BodyRenderer body=post##body />
+       </div>
+     }}
+  </div>;
 };
-
-let jsComponent =
-  ReasonReact.wrapReasonForJs(~component, jsProps =>
-    make(~post=PhenomicPresetReactApp.jsEdge(jsProps##post))
-  );
 
 let queries = props => {
   let post =

--- a/examples/reason-react-app/src/components/Post.re
+++ b/examples/reason-react-app/src/components/Post.re
@@ -2,8 +2,9 @@ open Helpers;
 
 [@react.component]
 let make = (~post) => {
+  let post' = PhenomicPresetReactApp.jsEdge(post);
   <div>
-    {switch ((post: Types.postNode)) {
+    {switch ((post': Types.postNode)) {
      | Inactive
      | Loading => "Loading ..." |> text
      | Errored => <ErrorPage />

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.0",
     "babel-jest": "^23.6.0",
-    "bs-platform": "^5.0.0",
+    "bs-platform": "^5.0.3",
     "chalk": "^1.1.3",
     "cross-env": "^2.0.0",
     "cross-spawn": "^5.1.0",
@@ -147,5 +147,8 @@
     "website",
     "examples/*",
     "packages/*"
-  ]
+  ],
+  "dependencies": {
+    "reason-react": "^0.7.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.0",
     "babel-jest": "^23.6.0",
-    "bs-platform": "^5.0.3",
+    "bs-platform": "^5.0.4",
     "chalk": "^1.1.3",
     "cross-env": "^2.0.0",
     "cross-spawn": "^5.1.0",
@@ -147,8 +147,5 @@
     "website",
     "examples/*",
     "packages/*"
-  ],
-  "dependencies": {
-    "reason-react": "^0.7.0"
-  }
+  ]
 }

--- a/packages/api-client/bsconfig.json
+++ b/packages/api-client/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/api-client",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/babel-preset/bsconfig.json
+++ b/packages/babel-preset/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/babel-preset",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/bs-platform/bsconfig.json
+++ b/packages/bs-platform/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/bs-platform",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [],
   "suffix": ".bs.js",

--- a/packages/bs-platform/package.json
+++ b/packages/bs-platform/package.json
@@ -15,7 +15,7 @@
     "lib/**/*.js"
   ],
   "devDependencies": {
-    "bs-platform": "^5.0.0",
+    "bs-platform": "^5.0.4",
     "cpy-cli": "^2.0.0",
     "replace": "^1.0.0"
   },

--- a/packages/cli/bsconfig.json
+++ b/packages/cli/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/cli",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/core/bsconfig.json
+++ b/packages/core/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/core",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/helpers-transform/bsconfig.json
+++ b/packages/helpers-transform/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/helpers-transform",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/plugin-api-related-content/bsconfig.json
+++ b/packages/plugin-api-related-content/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/plugin-api-related-content",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/plugin-bundler-webpack/bsconfig.json
+++ b/packages/plugin-bundler-webpack/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/plugin-bundler-webpack",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/plugin-collector-files/bsconfig.json
+++ b/packages/plugin-collector-files/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/plugin-collector-files",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/plugin-public-assets/bsconfig.json
+++ b/packages/plugin-public-assets/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/plugin-public-assets",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/plugin-renderer-react/bsconfig.json
+++ b/packages/plugin-renderer-react/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/plugin-renderer-react",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/plugin-renderer-react/src/bodyRenderer.re
+++ b/packages/plugin-renderer-react/src/bodyRenderer.re
@@ -1,5 +1,3 @@
-let component = ReasonReact.statelessComponent("BodyRenderer");
-
 type reasonChildren = list(reasonChild)
 and reasonChild =
   | String(string)
@@ -37,7 +35,8 @@ let rec jsTreeToReason = (jsChild: jsBody) =>
   | _ => Empty
   };
 
-let make = (~body: jsBody, _children) => {
+[@react.component]
+let make = (~body: jsBody) => {
   let rec renderChild = child =>
     switch (child) {
     | String(string) => ReasonReact.string(string)
@@ -67,5 +66,5 @@ let make = (~body: jsBody, _children) => {
       }
     | Empty => ReasonReact.null
     };
-  {...component, render: _self => body |> jsTreeToReason |> renderChild};
+  body |> jsTreeToReason |> renderChild;
 };

--- a/packages/plugin-renderer-react/src/bodyRenderer.re
+++ b/packages/plugin-renderer-react/src/bodyRenderer.re
@@ -39,7 +39,7 @@ let rec jsTreeToReason = (jsChild: jsBody) =>
 let make = (~body: jsBody) => {
   let rec renderChild = child =>
     switch (child) {
-    | String(string) => ReasonReact.string(string)
+    | String(string) => React.string(string)
     | Element(tag, originalProps, reasonChildren) =>
       switch (tag) {
       | "a" =>
@@ -49,22 +49,20 @@ let make = (~body: jsBody) => {
           activeStyle=[%bs.raw {| child[1].activeStyle |}]
           className=[%bs.raw {| child[1].className |}]
           activeClassName=[%bs.raw {| child[1].activeClassName |}]>
-          {ReasonReact.array(
-             Array.of_list(List.map(renderChild, reasonChildren)),
-           )}
+          {React.array(Array.of_list(List.map(renderChild, reasonChildren)))}
         </Link>
       | _ =>
         ReactDOMRe.createElement(
           tag,
           ~props=ReactDOMRe.objToDOMProps(originalProps),
           [|
-            ReasonReact.array(
+            React.array(
               Array.of_list(List.map(renderChild, reasonChildren)),
             ),
           |],
         )
       }
-    | Empty => ReasonReact.null
+    | Empty => React.null
     };
   body |> jsTreeToReason |> renderChild;
 };

--- a/packages/plugin-renderer-react/src/link.re
+++ b/packages/plugin-renderer-react/src/link.re
@@ -2,12 +2,12 @@
 [@react.component]
 external make:
   (
-    ~href: option(string)=?,
-    ~style: option(ReactDOMRe.Style.t)=?,
-    ~activeStyle: option(ReactDOMRe.Style.t)=?,
-    ~className: option(string)=?,
-    ~activeClassName: option(string)=?,
-    ~children,
+    ~href: string=?,
+    ~style: ReactDOMRe.Style.t=?,
+    ~activeStyle: ReactDOMRe.Style.t=?,
+    ~className: string=?,
+    ~activeClassName: string=?,
+    ~children: React.element
   ) =>
   React.element =
   "default";

--- a/packages/plugin-renderer-react/src/link.re
+++ b/packages/plugin-renderer-react/src/link.re
@@ -1,13 +1,13 @@
 [@bs.module "@phenomic/plugin-renderer-react/lib/components/Link"]
 [@react.component]
-external link:
+external make:
   (
     ~href: option(string)=?,
     ~style: option(ReactDOMRe.Style.t)=?,
     ~activeStyle: option(ReactDOMRe.Style.t)=?,
     ~className: option(string)=?,
     ~activeClassName: option(string)=?,
-    ~children: array(React.element)
+    ~children,
   ) =>
   React.element =
   "default";

--- a/packages/plugin-renderer-react/src/link.re
+++ b/packages/plugin-renderer-react/src/link.re
@@ -1,23 +1,3 @@
 [@bs.module "@phenomic/plugin-renderer-react/lib/components/Link"]
-external link: ReasonReact.reactClass = "default";
-
-let make =
-    (
-      ~href: option(string)=?,
-      ~style: option(ReactDOMRe.Style.t)=?,
-      ~activeStyle: option(ReactDOMRe.Style.t)=?,
-      ~className: option(string)=?,
-      ~activeClassName: option(string)=?,
-      children,
-    ) =>
-  ReasonReact.wrapJsForReason(
-    ~reactClass=link,
-    ~props={
-      "href": Js.Nullable.fromOption(href),
-      "style": Js.Nullable.fromOption(style),
-      "activeStyle": Js.Nullable.fromOption(activeStyle),
-      "className": Js.Nullable.fromOption(className),
-      "activeClassName": Js.Nullable.fromOption(activeClassName),
-    },
-    children,
-  );
+[@react.component]
+external link: React.element = "default";

--- a/packages/plugin-renderer-react/src/link.re
+++ b/packages/plugin-renderer-react/src/link.re
@@ -1,3 +1,13 @@
 [@bs.module "@phenomic/plugin-renderer-react/lib/components/Link"]
 [@react.component]
-external link: React.element = "default";
+external link:
+  (
+    ~href: option(string)=?,
+    ~style: option(ReactDOMRe.Style.t)=?,
+    ~activeStyle: option(ReactDOMRe.Style.t)=?,
+    ~className: option(string)=?,
+    ~activeClassName: option(string)=?,
+    ~children: array(React.element)
+  ) =>
+  React.element =
+  "default";

--- a/packages/plugin-renderer-react/src/phenomicRendererReactClient.re
+++ b/packages/plugin-renderer-react/src/phenomicRendererReactClient.re
@@ -1,14 +1,14 @@
 [@bs.module "@phenomic/plugin-renderer-react/lib/client"]
-external createContainer_: (React.component('a), Js.t({..})) => React.element =
+external createContainer_: (React.component('a), Js.t({..})) => React.component('b) =
   "createContainer";
 
 [@bs.module "@phenomic/plugin-renderer-react/lib/client"]
-external withPhenomicApi_: (React.component('a), Js.t({..})) => React.element =
+external withPhenomicApi_: (React.component('a), Js.t({..})) => React.component('b) =
   "withPhenomicApi";
 
 [@bs.module "@phenomic/plugin-renderer-react/lib/client"]
 external withInitialProps_:
-  (React.component('a), Js.t({..})) => React.element =
+  (React.component('a), Js.t({..})) => React.component('b) =
   "withInitialProps";
 
 module BodyRenderer = BodyRenderer;

--- a/packages/plugin-renderer-react/src/phenomicRendererReactClient.re
+++ b/packages/plugin-renderer-react/src/phenomicRendererReactClient.re
@@ -1,16 +1,16 @@
-[@bs.module "@phenomic/plugin-renderer-react/lib/client"]
+[@bs.module "@phenomic/plugin-renderer-react/lib/client"] [@react.component]
 external createContainer_:
-  (ReasonReact.reactClass, Js.t({..})) => ReasonReact.reactClass =
+  (ReasonReact.reactClass, Js.t({..})) => React.element =
   "createContainer";
 
-[@bs.module "@phenomic/plugin-renderer-react/lib/client"]
+[@bs.module "@phenomic/plugin-renderer-react/lib/client"] [@react.component]
 external withPhenomicApi_:
-  (ReasonReact.reactClass, Js.t({..})) => ReasonReact.reactClass =
+  (ReasonReact.reactClass, Js.t({..})) => React.element =
   "withPhenomicApi";
 
-[@bs.module "@phenomic/plugin-renderer-react/lib/client"]
+[@bs.module "@phenomic/plugin-renderer-react/lib/client"] [@react.component]
 external withInitialProps_:
-  (ReasonReact.reactClass, Js.t({..})) => ReasonReact.reactClass =
+  (ReasonReact.reactClass, Js.t({..})) => React.element =
   "withInitialProps";
 
 module BodyRenderer = BodyRenderer;

--- a/packages/plugin-renderer-react/src/phenomicRendererReactClient.re
+++ b/packages/plugin-renderer-react/src/phenomicRendererReactClient.re
@@ -1,16 +1,14 @@
 [@bs.module "@phenomic/plugin-renderer-react/lib/client"]
-external createContainer_:
-  (ReasonReact.reactClass, Js.t({..})) => React.element =
+external createContainer_: (React.component('a), Js.t({..})) => React.element =
   "createContainer";
 
 [@bs.module "@phenomic/plugin-renderer-react/lib/client"]
-external withPhenomicApi_:
-  (ReasonReact.reactClass, Js.t({..})) => React.element =
+external withPhenomicApi_: (React.component('a), Js.t({..})) => React.element =
   "withPhenomicApi";
 
 [@bs.module "@phenomic/plugin-renderer-react/lib/client"]
 external withInitialProps_:
-  (ReasonReact.reactClass, Js.t({..})) => React.element =
+  (React.component('a), Js.t({..})) => React.element =
   "withInitialProps";
 
 module BodyRenderer = BodyRenderer;

--- a/packages/plugin-renderer-react/src/phenomicRendererReactClient.re
+++ b/packages/plugin-renderer-react/src/phenomicRendererReactClient.re
@@ -1,14 +1,14 @@
-[@bs.module "@phenomic/plugin-renderer-react/lib/client"] [@react.component]
+[@bs.module "@phenomic/plugin-renderer-react/lib/client"]
 external createContainer_:
   (ReasonReact.reactClass, Js.t({..})) => React.element =
   "createContainer";
 
-[@bs.module "@phenomic/plugin-renderer-react/lib/client"] [@react.component]
+[@bs.module "@phenomic/plugin-renderer-react/lib/client"]
 external withPhenomicApi_:
   (ReasonReact.reactClass, Js.t({..})) => React.element =
   "withPhenomicApi";
 
-[@bs.module "@phenomic/plugin-renderer-react/lib/client"] [@react.component]
+[@bs.module "@phenomic/plugin-renderer-react/lib/client"]
 external withInitialProps_:
   (ReasonReact.reactClass, Js.t({..})) => React.element =
   "withInitialProps";

--- a/packages/plugin-rss-feed/bsconfig.json
+++ b/packages/plugin-rss-feed/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/plugin-rss-feed",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/plugin-sitemap/bsconfig.json
+++ b/packages/plugin-sitemap/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/plugin-sitemap",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/plugin-transform-asciidoc/bsconfig.json
+++ b/packages/plugin-transform-asciidoc/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/plugin-transform-asciidoc",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/plugin-transform-json/bsconfig.json
+++ b/packages/plugin-transform-json/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/plugin-transform-json",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/plugin-transform-markdown/bsconfig.json
+++ b/packages/plugin-transform-markdown/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/plugin-transform-markdown",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/packages/preset-react-app/bsconfig.json
+++ b/packages/preset-react-app/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "@phenomic/preset-react-app",
   "refmt": 3,
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1744,10 +1744,10 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@moox/bs-react-helmet@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@moox/bs-react-helmet/-/bs-react-helmet-1.0.0.tgz#554b1ccc03e3ef62f09910ac7294d80b41efa1f3"
-  integrity sha512-lYvu5lI5Pt2LDbYKnLOYH0YHuTGqeLPkeF0rykQdNtd4aEDLQlaE98QCraR7mvdNPxZSGFQJ8UPLNiGKqDgLsw==
+"@moox/bs-react-helmet@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@moox/bs-react-helmet/-/bs-react-helmet-2.0.0.tgz#d1bca09ff1d2c31d0a76a93a0660ef81cb74353d"
+  integrity sha512-2Pjd46s8VR8E9xWztCw7t2JoM9A7y7wm4kwybU7SYHDJY1INQtyvpQUbpBcbBe5Vpq0UOM4UnQFkuAzkWNb+WQ==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2982,6 +2982,11 @@ bs-platform@^5.0.0:
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.0.tgz#f9fded818bafc3891aeb85eb4e0d95b8d8f8b4d7"
   integrity sha512-zxLobdIaf/r7go47hOgxcd6C0ANh7MYMEtZNb9Al7JdoekzFZI50F4GpZpP8kMh9Z+M5PoPE1WuryT4S8mT8Kg==
 
+bs-platform@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.3.tgz#2b167603ef52574cb9534fabab702f6013715e6c"
+  integrity sha512-GAeypBebeDGTay5kJ3v5Z3Whp1Q4zQ0hAttflVtPG3zps88xDZnVAlS3JGIIBDmJFEMyNtv5947a/IWKvWXcPw==
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -10322,6 +10327,16 @@ react-dev-utils@^4.2.1:
     prop-types "^15.6.2"
     scheduler "^0.13.4"
 
+react-dom@>=16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
+
 react-element-to-jsx-string@^12.0.0:
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-12.0.0.tgz#d6c02272cb2268b8b3d98272adf0a4462fd75019"
@@ -10449,6 +10464,16 @@ react-topbar-progress-indicator@^2.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.4"
+
+react@>=16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
 
 read-all-stream@^3.0.0:
   version "3.1.0"
@@ -10592,6 +10617,14 @@ reason-react@^0.6.0:
   dependencies:
     react ">=15.0.0 || >=16.0.0"
     react-dom ">=15.0.0 || >=16.0.0"
+
+reason-react@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.7.0.tgz#46a975c321e81cd51310d7b1a02418ca7667b0d6"
+  integrity sha512-czR/f0lY5iyLCki9gwftOFF5Zs40l7ZSFmpGK/Z6hx2jBVeFDmIiXB8bAQW/cO6IvtuEt97OmsYueiuOYG9XjQ==
+  dependencies:
+    react ">=16.8.1"
+    react-dom ">=16.8.1"
 
 recursive-readdir@2.2.1:
   version "2.2.1"
@@ -11195,6 +11228,14 @@ scheduler@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.4.tgz#8fef05e7a3580c76c0364d2df5e550e4c9140298"
   integrity sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2977,15 +2977,10 @@ browserslist@^4.3.4:
     electron-to-chromium "^1.3.86"
     node-releases "^1.0.5"
 
-bs-platform@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.0.tgz#f9fded818bafc3891aeb85eb4e0d95b8d8f8b4d7"
-  integrity sha512-zxLobdIaf/r7go47hOgxcd6C0ANh7MYMEtZNb9Al7JdoekzFZI50F4GpZpP8kMh9Z+M5PoPE1WuryT4S8mT8Kg==
-
-bs-platform@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.3.tgz#2b167603ef52574cb9534fabab702f6013715e6c"
-  integrity sha512-GAeypBebeDGTay5kJ3v5Z3Whp1Q4zQ0hAttflVtPG3zps88xDZnVAlS3JGIIBDmJFEMyNtv5947a/IWKvWXcPw==
+bs-platform@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
+  integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==
 
 bser@^2.0.0:
   version "2.0.0"
@@ -10317,16 +10312,6 @@ react-dev-utils@^4.2.1:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-"react-dom@>=15.0.0 || >=16.0.0", react-dom@^16.8.0:
-  version "16.8.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.4.tgz#1061a8e01a2b3b0c8160037441c3bf00a0e3bc48"
-  integrity sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.4"
-
 react-dom@>=16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
@@ -10336,6 +10321,16 @@ react-dom@>=16.8.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
+
+react-dom@^16.8.0:
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.4.tgz#1061a8e01a2b3b0c8160037441c3bf00a0e3bc48"
+  integrity sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.4"
 
 react-element-to-jsx-string@^12.0.0:
   version "12.0.0"
@@ -10455,16 +10450,6 @@ react-topbar-progress-indicator@^2.0.0:
   dependencies:
     topbar "^0.1.3"
 
-"react@>=15.0.0 || >=16.0.0", "react@^15.6.2 || ^16.0", react@^16.8.0:
-  version "16.8.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.4.tgz#fdf7bd9ae53f03a9c4cd1a371432c206be1c4768"
-  integrity sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.4"
-
 react@>=16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
@@ -10474,6 +10459,16 @@ react@>=16.8.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
+
+"react@^15.6.2 || ^16.0", react@^16.8.0:
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.4.tgz#fdf7bd9ae53f03a9c4cd1a371432c206be1c4768"
+  integrity sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.4"
 
 read-all-stream@^3.0.0:
   version "3.1.0"
@@ -10609,14 +10604,6 @@ realpath-native@^1.0.0:
   integrity sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==
   dependencies:
     util.promisify "^1.0.0"
-
-reason-react@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.6.0.tgz#e9a7d6a10958161c3a12ef7fec1b6662edaae94a"
-  integrity sha512-FKzBDXE96KPyUbeRo2ToqUe9rl4IKgwegtjCXvyx0bzJXCKLqwiiN3OiOTH/siJS+/IZRZhBAHnd/R3VkRMsMQ==
-  dependencies:
-    react ">=15.0.0 || >=16.0.0"
-    react-dom ">=15.0.0 || >=16.0.0"
 
 reason-react@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
## Summary

This PR updates the ReasonReact jsx syntax to version 3, bsb-platform to 5.0.4, bs-react-helmet to 2.0.0, and reason-react to 0.7.0. In addition, the example reason-react-app is now updated to use jsx version 3. 